### PR TITLE
Add setup.py to allow for pip install. (#14)

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,4 +9,5 @@ psutil
 pylint==1.6.3
 pytest
 requests
+setuptools
 -e git://github.com/pacifica/pacifica-archiveinterface.git#egg=PacificaArchiveInterface

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,3 +3,4 @@ MySQL-python
 peewee
 psutil
 requests
+setuptools

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,11 @@
+#!/usr/bin/python
+"""Setup and install the cart."""
+from setuptools import setup
+
+setup(name='PacificaCartd',
+      version='1.0',
+      description='Pacifica Cartd',
+      author='David Brown',
+      author_email='david.brown@pnnl.gov',
+      packages=['cart'],
+      scripts=['CartServer.py', 'DatabaseCreate.py'])

--- a/travis/static-analysis.sh
+++ b/travis/static-analysis.sh
@@ -1,3 +1,3 @@
 #!/bin/bash
 pylint --rcfile=pylintrc cart
-pylint --rcfile=pylintrc CartServer DatabaseCreate
+pylint --rcfile=pylintrc CartServer DatabaseCreate setup.py

--- a/travis/test-deploy.sh
+++ b/travis/test-deploy.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-docker build -t pacifica/cartd .
+pip install .

--- a/travis/test-script.sh
+++ b/travis/test-script.sh
@@ -5,4 +5,5 @@ if [ "$RUN_LINTS" = "true" ] ; then
 else
   bash -xe ./travis/unit-tests.sh
   bash -xe ./travis/end-to-end.sh
+  bash -xe ./travis/test-deploy.sh
 fi


### PR DESCRIPTION
* add setup.py to install cart on the system

* let's add this back but using pip

* missed comma grr....

* doh, wrong name of file

* let's get pylint happy

* let's get setuptools there so pylint will go

* seems we got things wrong

### Description

[Describe what this change achieves]

### Issues Resolved

[List any existing issues this PR resolves]

### Check List

- [ ] All tests pass. See <https://github.com/pacifica/pacifica-docs/blob/master/development/TESTING.md>
- [ ] New functionality includes testing.
- [ ] New functionality has been documented in the README if applicable
